### PR TITLE
Adding fallbacks for Source Code Pro monospace font

### DIFF
--- a/public/stylesheets/app.css
+++ b/public/stylesheets/app.css
@@ -13,7 +13,7 @@ html{
 }
 body {
 	margin: 0;
-	font-family: Source Code Pro;
+	font-family: "Source Code Pro",	SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 	font-size: 12px;
 	height: 100%;
 }
@@ -262,7 +262,7 @@ h1 span{
 }
 .error{
 	color: #FF7B7B;
-}      
+}
 .success{
 	color: green;
 }


### PR DESCRIPTION
If the user does not have Source Code Pro installed, code in rendered in a variable-width font, which makes it very difficult to parse. This PR adds fallback monospace fonts that should cater for the majority of users.